### PR TITLE
Add dependency injection extensions

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,6 +4,12 @@ README.md
 LICENSE.md
 AssemblyAI/Realtime/RealtimeTranscriber.cs
 AssemblyAI/Realtime/WebSocketClient
-AssemblyAI.Test
+src/AssemblyAI/AssemblyAI.csproj
+src/AssemblyAI/AssemblyAIClient.cs
+src/AssemblyAI/ClientOptions.cs
+src/AssemblyAI/DependencyInjectionExtensions.cs
+
+src/AssemblyAI.Test
+
 Samples
 **/*.fernignore.*

--- a/src/AssemblyAI.Test/AssemblyAI.Test.csproj
+++ b/src/AssemblyAI.Test/AssemblyAI.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -10,6 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0"/>
         <PackageReference Include="NUnit" Version="3.13.3"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2"/>

--- a/src/AssemblyAI.Test/DiClientOptionsTests.cs
+++ b/src/AssemblyAI.Test/DiClientOptionsTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using AssemblyAI.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace AssemblyAI.Test;
+
+[TestFixture]
+public class DependencyInjectionClientOptionsTests
+{
+    private static readonly ClientOptions ValidAssemblyAIOptions = new()
+    {
+        ApiKey = "MyAssemblyAIApiKey",
+        BaseUrl = "https://api.assemblyai.com",
+        MaxRetries = 2,
+        TimeoutInSeconds = 30
+    };
+
+    [Test]
+    public void AddAssemblyAIClient_With_Callback_Should_Match_Configuration()
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton(BuildEmptyConfiguration());
+        serviceCollection.AddAssemblyAIClient((_, options) =>
+        {
+            options.ApiKey = ValidAssemblyAIOptions.ApiKey;
+            options.BaseUrl = ValidAssemblyAIOptions.BaseUrl;
+            options.MaxRetries = ValidAssemblyAIOptions.MaxRetries;
+            options.TimeoutInSeconds = ValidAssemblyAIOptions.TimeoutInSeconds;
+        });
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var assemblyAIClientOptions = serviceProvider.GetService<IOptions<ClientOptions>>()?.Value;
+
+        var expectedJson = JsonSerializer.Serialize(ValidAssemblyAIOptions);
+        var actualJson = JsonSerializer.Serialize(assemblyAIClientOptions);
+
+        Assert.That(actualJson, Is.EqualTo(expectedJson));
+    }
+
+    [Test]
+    public async Task AddAssemblyAIClient_From_Configuration_Should_Reload_On_Change()
+    {
+        const string optionsFile = "ClientOptions.json";
+        if (File.Exists(optionsFile)) File.Delete(optionsFile);
+        var jsonText = JsonSerializer.Serialize(new { AssemblyAI = ValidAssemblyAIOptions });
+        await File.WriteAllTextAsync(optionsFile, jsonText);
+
+        var serviceCollection = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile(optionsFile, optional: false, reloadOnChange: true)
+            .Build();
+
+        serviceCollection.AddSingleton<IConfiguration>(configuration);
+        serviceCollection.AddAssemblyAIClient();
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        ClientOptions updatedOptions = new()
+        {
+            ApiKey = "UpdatedApiKey",
+            BaseUrl = "https://api.updated.assemblyai.com",
+            MaxRetries = 3,
+            TimeoutInSeconds = 45
+        };
+
+        jsonText = JsonSerializer.Serialize(new { AssemblyAI = updatedOptions });
+        await File.WriteAllTextAsync(optionsFile, jsonText);
+
+        // Simulate waiting for the option change to be detected
+        await Task.Delay(1000); // This is a simplification. In real tests, use a more reliable method to wait for changes.
+
+        var monitor = serviceProvider.GetRequiredService<IOptionsMonitor<ClientOptions>>();
+        var options = monitor.CurrentValue;
+
+        var expectedJson = JsonSerializer.Serialize(updatedOptions);
+        var actualJson = JsonSerializer.Serialize(options);
+        Assert.That(actualJson, Is.EqualTo(expectedJson));
+    }
+
+    private static IConfiguration BuildEmptyConfiguration() => new ConfigurationBuilder().Build();
+}

--- a/src/AssemblyAI.Test/DiClientTests.cs
+++ b/src/AssemblyAI.Test/DiClientTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace AssemblyAI.Test;
+
+[TestFixture]
+public class DiClientTests
+{
+    [Test]
+    public void AssemblyAIClient_Should_Be_Correctly_Configured_From_DI()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                { "AssemblyAI:ApiKey", "test_api_key" },
+                { "AssemblyAI:BaseUrl", "https://api.test.assemblyai.com" },
+                { "AssemblyAI:MaxRetries", "3" },
+                { "AssemblyAI:TimeoutInSeconds", "60" }
+            }!)
+            .Build();
+
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddAssemblyAIClient();
+
+        // Act
+        var serviceProvider = services.BuildServiceProvider();
+        var client = serviceProvider.GetService<AssemblyAIClient>();
+
+        // Assert
+        Assert.That(client, Is.Not.Null);
+        Assert.That(client.Files, Is.Not.Null);
+        Assert.That(client.Transcripts, Is.Not.Null);
+        Assert.That(client.Realtime, Is.Not.Null);
+        Assert.That(client.Lemur, Is.Not.Null);
+    }
+
+    [Test]
+    public void AssemblyAIClient_Throws_Exception_When_Configuration_Missing()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build(); // Empty configuration
+
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddAssemblyAIClient();
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(() => serviceProvider.GetService<AssemblyAIClient>());
+        Assert.That(exception.Message, Is.EqualTo("AssemblyAI:ApiKey is required."));
+    }
+}

--- a/src/AssemblyAI/AssemblyAI.csproj
+++ b/src/AssemblyAI/AssemblyAI.csproj
@@ -31,6 +31,14 @@
         </PackageReference>
     </ItemGroup>
 
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net7.0' Or '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="OneOf" Version="3.0.263" />
         <PackageReference Include="OneOf.Extended" Version="3.0.263" />

--- a/src/AssemblyAI/AssemblyAI.csproj
+++ b/src/AssemblyAI/AssemblyAI.csproj
@@ -42,7 +42,7 @@
     <ItemGroup>
         <PackageReference Include="OneOf" Version="3.0.263" />
         <PackageReference Include="OneOf.Extended" Version="3.0.263" />
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
+        <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AssemblyAI/AssemblyAIClient.cs
+++ b/src/AssemblyAI/AssemblyAIClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using AssemblyAI;
 using AssemblyAI.Core;
 
@@ -9,17 +10,25 @@ public partial class AssemblyAIClient
 {
     private RawClient _client;
 
-    public AssemblyAIClient(string? apiKey = null, ClientOptions? clientOptions = null)
+    public AssemblyAIClient(string apiKey) : this(new ClientOptions
     {
+        ApiKey = apiKey
+    })
+    {
+    }
+
+    public AssemblyAIClient(ClientOptions clientOptions)
+    {
+        clientOptions.HttpClient ??= new HttpClient();
         _client = new RawClient(
             new Dictionary<string, string>()
             {
-                { "Authorization", apiKey },
+                { "Authorization", clientOptions.ApiKey },
                 { "X-Fern-Language", "C#" },
                 { "X-Fern-SDK-Name", "AssemblyAI" },
                 { "X-Fern-SDK-Version", "0.0.2-alpha" },
             },
-            clientOptions ?? new ClientOptions()
+            clientOptions
         );
         Files = new FilesClient(_client);
         Transcripts = new TranscriptsClient(_client);

--- a/src/AssemblyAI/AssemblyAIClient.cs
+++ b/src/AssemblyAI/AssemblyAIClient.cs
@@ -19,6 +19,11 @@ public partial class AssemblyAIClient
 
     public AssemblyAIClient(ClientOptions clientOptions)
     {
+        if (string.IsNullOrEmpty(clientOptions.ApiKey))
+        {
+            throw new ArgumentException("AssemblyAI API Key is required.");
+        }
+        
         clientOptions.HttpClient ??= new HttpClient();
         _client = new RawClient(
             new Dictionary<string, string>()

--- a/src/AssemblyAI/ClientOptions.cs
+++ b/src/AssemblyAI/ClientOptions.cs
@@ -1,10 +1,11 @@
 #nullable enable
 
 using System.Net.Http;
+using AssemblyAI.Core;
 
-namespace AssemblyAI.Core;
+namespace AssemblyAI;
 
-public partial class ClientOptions
+public class ClientOptions
 {
     /// <summary>
     /// The AssemblyAI API key

--- a/src/AssemblyAI/Core/ClientOptions.cs
+++ b/src/AssemblyAI/Core/ClientOptions.cs
@@ -1,29 +1,33 @@
-using System.Net.Http;
-using AssemblyAI.Core;
-
 #nullable enable
+
+using System.Net.Http;
 
 namespace AssemblyAI.Core;
 
 public partial class ClientOptions
 {
     /// <summary>
+    /// The AssemblyAI API key
+    /// </summary>
+    public required string ApiKey { get; set; }
+    
+    /// <summary>
     /// The Base URL for the API.
     /// </summary>
-    public string BaseUrl { get; init; } = Environments.DEFAULT;
+    public string BaseUrl { get; set; } = Environments.DEFAULT;
 
     /// <summary>
     /// The http client used to make requests.
     /// </summary>
-    public HttpClient HttpClient { get; init; } = new HttpClient();
+    public HttpClient? HttpClient { get; set; }
 
     /// <summary>
     /// The http client used to make requests.
     /// </summary>
-    public int MaxRetries { get; init; } = 2;
+    public int MaxRetries { get; set; } = 2;
 
     /// <summary>
     /// The timeout for the request in seconds.
     /// </summary>
-    public int TimeoutInSeconds { get; init; } = 30;
+    public int TimeoutInSeconds { get; set; } = 30;
 }

--- a/src/AssemblyAI/DependencyInjectionExtensions.cs
+++ b/src/AssemblyAI/DependencyInjectionExtensions.cs
@@ -1,0 +1,93 @@
+#if NET6_0_OR_GREATER || NETSTANDARD2_0_OR_GREATER
+using AssemblyAI.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace AssemblyAI;
+
+public static class DependencyInjectionExtensions
+{
+    private const string AssemblyAIHttpClientName = "AssemblyAI";
+
+    public static IServiceCollection AddAssemblyAIClient(this IServiceCollection services)
+    {
+        var optionsBuilder = services.AddOptions<ClientOptions>();
+        optionsBuilder.BindConfiguration("AssemblyAI");
+        Validate(optionsBuilder);
+        AddServices(services);
+        return services;
+    }
+
+    public static IServiceCollection AddAssemblyAIClient(
+        this IServiceCollection services,
+        IConfiguration namedConfigurationSection
+    )
+    {
+        var optionsBuilder = services.AddOptions<ClientOptions>();
+        optionsBuilder.Bind(namedConfigurationSection);
+        Validate(optionsBuilder);
+        AddServices(services);
+        return services;
+    }
+
+    public static IServiceCollection AddAssemblyAIClient(
+        this IServiceCollection services,
+        Action<ClientOptions> configureOptions
+    )
+        => AddAssemblyAIClient(services, (_, options) => configureOptions(options));
+
+
+    public static IServiceCollection AddAssemblyAIClient(
+        this IServiceCollection services,
+        Action<IServiceProvider, ClientOptions> configureOptions
+    )
+    {
+        var optionsBuilder = services.AddOptions<ClientOptions>();
+        optionsBuilder.Configure<IServiceProvider>((options, provider) => configureOptions(provider, options));
+        Validate(optionsBuilder);
+        AddServices(services);
+        return services;
+    }
+
+
+    public static IServiceCollection AddAssemblyAIClient(
+        this IServiceCollection services,
+        ClientOptions options
+    )
+    {
+        var optionsBuilder = services.AddOptions<ClientOptions>();
+
+        optionsBuilder.Configure<IServiceProvider>((optionsToConfigure, _) =>
+        {
+            optionsToConfigure.ApiKey = options.ApiKey;
+            optionsToConfigure.HttpClient = options.HttpClient;
+            optionsToConfigure.BaseUrl = options.BaseUrl;
+            optionsToConfigure.MaxRetries = options.MaxRetries;
+            optionsToConfigure.TimeoutInSeconds = options.TimeoutInSeconds;
+        });
+        Validate(optionsBuilder);
+        AddServices(services);
+        return services;
+    }
+
+    private static void AddServices(IServiceCollection services)
+    {
+        services.AddHttpClient(AssemblyAIHttpClientName);
+        services.AddScoped(CreateAssemblyAIClient);
+    }
+
+    private static void Validate(OptionsBuilder<ClientOptions> optionsBuilder)
+    {
+        optionsBuilder.Validate(options => !string.IsNullOrEmpty(options.ApiKey), 
+            "AssemblyAI:ApiKey is required."
+        );
+    }
+    private static AssemblyAIClient CreateAssemblyAIClient(IServiceProvider provider)
+    {
+        var options = provider.GetRequiredService<IOptionsSnapshot<ClientOptions>>().Value;
+        options.HttpClient ??= provider.GetRequiredService<IHttpClientFactory>().CreateClient(AssemblyAIHttpClientName);
+        return new AssemblyAIClient(options);
+    }
+}
+#endif


### PR DESCRIPTION
Add dependency injections extensions.
These extensions let users add the AssemblyAI client to .NET's default DI container, and let users configure the client using the .NET configuration system.